### PR TITLE
#12 #13 イベント参加管理 Issue1/2 誰が参加するかDBに保存する・誰が参加／不参加の情報をDBに保存する

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -28,7 +28,8 @@ DROP TABLE IF EXISTS event_attendance;
 CREATE TABLE event_attendance (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   event_id INT NOT NULL,
-  user_id INT,
+  user_id INT NOT NULL,
+  status INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME
@@ -54,9 +55,9 @@ INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
 
-INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=2;
-INSERT INTO event_attendance SET event_id=2;
-INSERT INTO event_attendance SET event_id=3;
+INSERT INTO event_attendance SET event_id=1, user_id=1, status=1;
+INSERT INTO event_attendance SET event_id=1, user_id=2, status=1;
+INSERT INTO event_attendance SET event_id=1, user_id=3, status=2;
+INSERT INTO event_attendance SET event_id=2, user_id=1, status=2;
+INSERT INTO event_attendance SET event_id=2, user_id=2, status=1;
+INSERT INTO event_attendance SET event_id=2, user_id=3, status=2;


### PR DESCRIPTION
## 関連イシュー
#12 イベント参加管理 Issue1/2 誰が参加するかDBに保存する
#13 誰が参加／不参加の情報をDBに保存する

## 検証したこと
- [x] DBの情報から誰が参加する予定か確認可能
- [x] DBの情報から誰が参加／不参加の予定か確認可能

## 関連プルリク
#51 
#56 

## エビデンス
### event_attendanceテーブルにカラム（status）を追加
![スクリーンショット (641)](https://user-images.githubusercontent.com/94539342/188769638-09433ee4-851b-442f-a274-b1d7bc0d65bd.png)
### 参加／不参加の状態を数字（1；参加・2；不参加）で表し、select文を用いて出力した様子を下記に示します
【詳細】event_idでは対象のイベントを取得（下の画像ではevent_idが1と2になっているものに限定して取得しています、初期データは15個ありましたが、その中の2つだけ例として取得しています）
【詳細】user_idでは対象のuserを取得
【詳細】statusでは対象のuserが対象のイベントで参加／不参加のどちらの状態なのかを数字で表しています
![スクリーンショット (638)](https://user-images.githubusercontent.com/94539342/188769213-d0c85c15-c73d-45cf-831e-e896c6d0c0ae.png)

### フロントにも反映される
<img width="1432" alt="スクリーンショット 2022-09-08 21 38 31" src="https://user-images.githubusercontent.com/86900758/189123815-03c93cb0-1b99-4e2c-a9dc-c59b8f6c9385.png">
