### PR TITLE
#1 イベント一覧 Issue1 開催日が過去のイベントを表示しない

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -29,16 +29,17 @@ INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='20
 INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
 INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
 INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
+INSERT INTO events SET name='スペモク', start_at='2021/08/10
+ 20:00', end_at='2021/08/10 22:00';
 INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
 INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
 INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2022/09/22 23:00';
+INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2022/12/23 23:00';
+INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2022/11/24 22:00';
+INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2022/10/22 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2022/09/13 22:00';
+INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2022/10/07 22:00';
 
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -34,12 +34,12 @@ INSERT INTO events SET name='スペモク', start_at='2021/08/10
 INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
 INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
 INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2022/09/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2022/12/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2022/11/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2022/10/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2022/09/13 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2022/10/07 22:00';
+INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
+INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
+INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/10/22 18:00', end_at='2022/10/22 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2022/09/13 10:00', end_at='2022/09/13 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:20', end_at='2022/09/09 23:12';
 
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/src/admin/admin.css
+++ b/src/admin/admin.css
@@ -1,0 +1,61 @@
+html {
+  font-size: 62.5%;
+}
+
+a {
+  text-decoration: none;
+  color: black;
+}
+
+a:hover {
+  opacity: 0.4;
+}
+
+header {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.header_logo img {
+  width: 40%;
+}
+
+.header_logo {
+  width: 60%;
+}
+
+.header_title p {
+  font-size: 1.6rem;
+}
+
+main {
+  background-color: rgb(246, 244, 244);
+  width: 94%;
+  margin: 0 auto;
+  padding: 40px;
+}
+
+h1 {
+  font-size: 4rem;
+}
+
+.registration_form p {
+  font-size: 2rem;
+}
+
+.registration_form div {
+  margin-bottom: 40px;
+}
+
+/* event_list.phpについての記述 */
+.each_event{
+  background-color: #fff;
+display: flex;
+justify-content: space-between;
+padding: 10px;
+margin: 24px;
+}
+.each_event p{
+  font-size: 1.2rem;
+}

--- a/src/admin/event_edit.html
+++ b/src/admin/event_edit.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/admin.css">
+  <title>イベント登録</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_registration.html">イベント登録</a></p>
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_list.html">イベント一覧</a></p>
+    </div>
+  </header>
+  <main>
+    <div>
+      <h1>イベント変更</h1>
+    </div>
+    <!-- get, post???????? -->
+
+    <!-- 
+ここのフォームにはすでに入力されている内容（イベント名など）が入る
+     -->
+    <form action="" method="get" class="registration_form">
+      <div>
+        <p>イベント名<br><input type="text"></p>
+      </div>
+      <div>
+        <p>開始時間<br><input type="datetime-local"></p>
+      </div>
+      <div>
+        <p>終了時間<br><input type="datetime-local"></p>
+      </div>
+      <div>
+        <p>イベント内容<br><textarea cols="30" rows="10"></textarea></p>
+      </div>
+      <div>
+        <input type="submit" value="変更">
+      </div>
+    </form>
+
+
+  </main>
+</body>
+
+</html>

--- a/src/admin/event_list.html
+++ b/src/admin/event_list.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/admin.css">
+  <title>イベント一覧</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_registration.html">イベント登録</a></p>
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_list.html">イベント一覧</a></p>
+    </div>
+  </header>
+  <main>
+
+    <div>
+      <h1>イベント一覧</h1>
+    </div>
+    <div class="each_event">
+      <div class="each_event_contents">
+        <p>イベント名</p>
+        <p>2022年2月10日 10:00~12:00</p>
+      </div>
+      <div class="each_event_edit">
+        <p><a href="../admin/event_edit.html">編集</a></p>
+      </div>
+    </div>
+<!-- 複製 -->
+    <div class="each_event">
+      <div class="each_event_contents">
+        <p>イベント名</p>
+        <p>2022年2月10日 10:00~12:00</p>
+      </div>
+      <div class="each_event_edit">
+        <p><a href="../admin/event_edit.html">編集</a></p>
+      </div>
+    </div>
+
+
+
+  </main>
+</body>
+
+</html>

--- a/src/admin/event_registration.html
+++ b/src/admin/event_registration.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/admin.css">
+  <title>イベント登録</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_registration.html">イベント登録</a></p>
+    </div>
+    <div class="header_title">
+    <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+    <p><a href="event_list.html">イベント一覧</a></p>
+    </div>
+  </header>
+  <main>
+  <div>
+    <h1>イベント登録</h1>
+  </div>
+  <!-- get, post???????? -->
+  <form action="" method="get" class="registration_form">
+    <div>
+      <p>イベント名<br><input type="text"></p>
+    </div>
+    <div>
+      <p>開始時間<br><input type="datetime-local"></p>
+    </div>
+    <div>
+      <p>終了時間<br><input type="datetime-local"></p>
+    </div>
+    <div>
+      <p>イベント内容<br><textarea cols="30" rows="10"></textarea></p>
+    </div>
+    <div>
+      <input type="submit" value="登録">
+    </div>
+  </form>
+
+
+</main>
+</body>
+
+</html>

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,9 @@
 <?php
 require('dbconnect.php');
+echo date("Y-m-d H:i:s");
+echo DATE("Y-m-d H:i:s");
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id where end_at >= now()  GROUP BY events.id');
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,6 @@
 <?php
 require('dbconnect.php');
-echo date("Y-m-d H:i:s");
-echo DATE("Y-m-d H:i:s");
+
 
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id where end_at >= now()  GROUP BY events.id');
 $events = $stmt->fetchAll();


### PR DESCRIPTION
## 関連イシュー
#1 開催日が過去のイベントを表示しない

## 検証したこと
・ダミーデータの掲載終了時間（eventsテーブルのend_at）を変更して、該当する内容のみ表示されることを確認
・過去データ（2021年など）も存在するが、表示はされない

## 関連PR
#55 

## エビデンス
![image](https://user-images.githubusercontent.com/86918664/189134763-5e7e7f87-b51b-4cf8-bfe8-00be0aa999ac.png)
![スクリーンショット (35)](https://user-images.githubusercontent.com/86918664/189135415-2da63323-2df3-47b6-9edf-5501f84f9f63.png)

