### PR TITLE
#21 管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -38,7 +38,7 @@ CREATE TABLE event_attendance (
 INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password='eddy';
 INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password='minn';
 
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/10 21:00', end_at='2022/09/10 23:00';
 INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
 INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
 INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
@@ -54,9 +54,9 @@ INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
 
+INSERT INTO event_attendance SET event_id=1, user_id='1';
+INSERT INTO event_attendance SET event_id=1, user_id='2';
 INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=1;
-INSERT INTO event_attendance SET event_id=2;
-INSERT INTO event_attendance SET event_id=2;
-INSERT INTO event_attendance SET event_id=3;
+INSERT INTO event_attendance SET event_id=2, user_id='1';
+INSERT INTO event_attendance SET event_id=2, user_id='2';
+INSERT INTO event_attendance SET event_id=3, user_id='1';

--- a/src/admin/css/admin.css
+++ b/src/admin/css/admin.css
@@ -1,0 +1,43 @@
+html{
+  font-size: 62.5%;
+}
+a{
+  text-decoration: none;
+  color: black;
+}
+a:hover{
+  opacity: 0.4;
+}
+
+header {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.header_logo img {
+  width: 40%;
+}
+
+.header_logo {
+  width: 60%;
+}
+.header_title p{
+  font-size: 1.6rem;
+}
+
+main {
+  background-color: rgb(246, 244, 244);
+  width: 94%;
+  margin: 0 auto;
+}
+h1{
+  font-size: 4rem;
+}
+
+.registration_form p{
+font-size: 2rem;
+}
+.registration_form div{
+  margin-bottom: 40px;
+}

--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -1,3 +1,35 @@
+<?php
+session_start();
+
+if(!empty($_POST['name'])) {
+  try {
+
+    $stmt = $db->prepare(
+      'INSERT INTO events
+        (name, start_at, end_at)
+        VALUES
+        (:name, :start_at, :end_at)'
+      );
+  
+    $name = $_POST['name'];
+    $start_at = $_POST['start_at'];
+    $end_at = $_POST['end_at'];
+    
+    $param = array(
+      ':name' => $name,
+      ':start_at' => $start_at,
+      ':end_at' => $end_at,
+    );
+  
+    $stmt->execute($param);
+  }catch (PDOException $e) {
+    echo 'データベースにアクセスできません！'.$e->getMessage();
+}
+  
+  } 
+  
+?>
+
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -27,19 +59,18 @@
   <div>
     <h1>イベント登録</h1>
   </div>
-  <!-- get, post???????? -->
-  <form action="" method="get" class="registration_form">
+  <form action="./event_registration.php" method="post" class="registration_form">
     <div>
-      <p>イベント名<br><input type="text"></p>
+      <p>イベント名<br><input type="text" name="name"></p>
     </div>
     <div>
-      <p>開始時間<br><input type="datetime-local"></p>
+      <p>開始時間<br><input type="datetime-local" name="start_at"></p>
     </div>
     <div>
-      <p>終了時間<br><input type="datetime-local"></p>
+      <p>終了時間<br><input type="datetime-local" name="end_at"></p>
     </div>
     <div>
-      <input type="submit" value="送信">
+    <button type="submit" name="button">登録する</button>
     </div>
   </form>
 

--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/css/admin.css">
+  <title>イベント登録</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+      <p><a href="event_registration.html">イベント登録</a></p>
+    </div>
+    <!-- <div class="header_title"> -->
+    <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
+    <!-- <p><a href="event_registration.html">イベント一覧</a></p>
+    </div> -->
+  </header>
+  <main>
+  <div>
+    <h1>イベント登録</h1>
+  </div>
+  <!-- get, post???????? -->
+  <form action="" method="get" class="registration_form">
+    <div>
+      <p>イベント名<br><input type="text"></p>
+    </div>
+    <div>
+      <p>開始時間<br><input type="datetime-local"></p>
+    </div>
+    <div>
+      <p>終了時間<br><input type="datetime-local"></p>
+    </div>
+    <div>
+      <input type="submit" value="送信">
+    </div>
+  </form>
+
+
+</main>
+</body>
+
+</html>

--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -1,15 +1,11 @@
 <?php
 session_start();
+require('../dbconnect.php');
 
 if(!empty($_POST['name'])) {
   try {
 
-    $stmt = $db->prepare(
-      'INSERT INTO events
-        (name, start_at, end_at)
-        VALUES
-        (:name, :start_at, :end_at)'
-      );
+    $stmt = $db->prepare('INSERT INTO events (name, start_at, end_at) VALUES (:name, :start_at, :end_at)');
   
     $name = $_POST['name'];
     $start_at = $_POST['start_at'];

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -2,21 +2,27 @@
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
-if (isset($_GET['eventId'])) {
+// if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
   try {
     $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
-    $stmt->execute(array($eventId));
+    // イベント情報の取得をする時に、参加状況を内部結合して、参加人数を記録している
+    // $stmt->execute(array($eventId));
+    $stmt->execute(array(1));
+    // ゲットしてきたイベントIDを指定
     $event = $stmt->fetch();
-    
+    // データの取得
     $start_date = strtotime($event['start_at']);
     $end_date = strtotime($event['end_at']);
+    // 日時を表記用の形に変更している
 
     $eventMessage = date("Y年m月d日", $start_date) . '（' . get_day_of_week(date("w", $start_date)) . '） ' . date("H:i", $start_date) . '~' . date("H:i", $end_date) . 'に' . $event['name'] . 'を開催します。<br>ぜひ参加してください。';
+    // メッセージ内容の指定
 
     if ($event['id'] % 3 === 1) $status = 0;
     elseif ($event['id'] % 3 === 2) $status = 1;
     else $status = 2;
+    // イベントIDに3つのステータスをつけているけど、何に使うの？？？？？？？？？？？？？
 
     $array = [
       'id' => $event['id'],
@@ -30,15 +36,18 @@ if (isset($_GET['eventId'])) {
       'status' => $status,
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
     ];
-    
     echo json_encode($array, JSON_UNESCAPED_UNICODE);
-  } catch(PDOException $e) {
+  } catch (PDOException $e) {
     echo $e->getMessage();
     exit();
   }
-}
+// } else {
+//   echo "yo";
+// }
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+

--- a/src/api/postEventAttendance.php
+++ b/src/api/postEventAttendance.php
@@ -1,0 +1,10 @@
+<?php
+require('../dbconnect.php');
+header('Content-Type: application/json; charset=UTF-8');
+
+$eventId = $_POST['eventId'];
+
+if ($eventId > 0) {
+  $stmt = $db->prepare('INSERT INTO event_attendance SET event_id=?');
+  $stmt->execute(array($eventId));
+}

--- a/src/api/sendMail.php
+++ b/src/api/sendMail.php
@@ -1,0 +1,66 @@
+<?php
+require('../dbconnect.php');
+// ・毎日やる
+$i = 0;
+while (true) {
+  try {
+    $stmt = $db->prepare('SELECT id, name, start_at, end_at from events');
+    $stmt->execute();
+    $events = $stmt->fetchAll(pdo::FETCH_ASSOC);
+    // print_r($events);
+
+    foreach ($events as $index => $event) {
+      $array = [
+        'id' => $event['id'],
+        'name' => $event['name'],
+        'date' => date("Y年m月d日", $start_date),
+        'start_at' => date("H:i", $start_date),
+        'end_at' => date("H:i", $end_date),
+      ];
+      $event_date = substr($event['start_at'], 0, 10);
+      $three_days_after = date("Y-m-d", strtotime("+3 day"));
+      if ($event_date == $three_days_after) {
+        $stmt = $db->prepare('SELECT name, email FROM users LEFT JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ?');
+        // 特定のイベントに対して、ユーザーを取得している
+        $stmt->execute(array($event['id']));
+        // ゲットしてきたイベントIDを指定
+        $participants = $stmt->fetchAll(pdo::FETCH_ASSOC);
+        // データの取得 
+
+        foreach ($participants as $index => $participant) {
+          // 【メール送信】
+          mb_language('ja');
+          mb_internal_encoding('UTF-8');
+
+          $to = $participant['email'];
+          $subject = "イベントリマインド";
+          $body = "本文";
+          $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+          $name = $participant['name'];
+          $date = $event_date;
+          $event = $array['name'];
+          $body = <<<EOT
+          {$name}さん
+          ${date}に${event}を開催します。
+          参加／不参加の回答をお願いします。
+          http://localhost/
+        EOT;
+
+          mb_send_mail($to, $subject, $body, $headers);
+          echo "メールを送信しました";
+        }
+      }
+    }
+  } catch (PDOException $e) {
+    echo $e->getMessage();
+    exit();
+  }
+
+  sleep(5);
+  $i = $i + 1;
+  if ($i == 3) {
+    break;
+  }
+}
+// ・全部のイベントに対してやる

--- a/src/api/sendMail.php
+++ b/src/api/sendMail.php
@@ -20,9 +20,9 @@ while (true) {
       $event_date = substr($event['start_at'], 0, 10);
       $three_days_after = date("Y-m-d", strtotime("+3 day"));
       if ($event_date == $three_days_after) {
-        $stmt = $db->prepare('SELECT name, email FROM users LEFT JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ?');
+        $stmt = $db->prepare('SELECT name, email FROM users');
         // 特定のイベントに対して、ユーザーを取得している
-        $stmt->execute(array($event['id']));
+        $stmt->execute();
         // ゲットしてきたイベントIDを指定
         $participants = $stmt->fetchAll(pdo::FETCH_ASSOC);
         // データの取得 

--- a/src/api/sendMail.php
+++ b/src/api/sendMail.php
@@ -1,8 +1,7 @@
 <?php
 require('../dbconnect.php');
-// ・毎日やる
-$i = 0;
-while (true) {
+
+
   try {
     $stmt = $db->prepare('SELECT id, name, start_at, end_at from events');
     $stmt->execute();
@@ -57,10 +56,4 @@ while (true) {
     exit();
   }
 
-  sleep(5);
-  $i = $i + 1;
-  if ($i == 3) {
-    break;
-  }
-}
 // ・全部のイベントに対してやる

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -1,11 +1,11 @@
 <?php
-require "../../dbconnect.php";
+require ("../../dbconnect.php");
 
 session_start();
 
 // セッション変数 $_SESSION["loggedin"]を確認。ログイン済だったらウェルカムページへリダイレクト
 if (isset($_SESSION["loggedin"]) && $_SESSION["loggedin"] === true) {
-  header("location: index.php");
+  header("location: ../../index.php");
   exit;
 }
 


### PR DESCRIPTION
## 関連イシュー
#21 管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空

## 関連プルリク
#39 #48 #54 

## 検証したこと
- 管理画面からイベント名、開催日時を入力して、イベント登録できる
- ユーザー画面のフロントに登録内容が反映される

## 備考
-  一度Dockerを落としてデータが消えてしまったあとでフロントの証明写真を撮ったので、時間が微妙にずれてしまいました。
- 管理者のみのアクセスは以下の追加PRで実装しました

## エビデンス
<img width="1439" alt="スクリーンショット 2022-09-07 15 18 34" src="https://user-images.githubusercontent.com/86900758/188803070-8cb2bed6-12d0-47e8-9479-ae29ddc55aa1.png">

<img width="430" alt="スクリーンショット 2022-09-07 15 22 05" src="https://user-images.githubusercontent.com/86900758/188803638-7425a5e9-8f19-4f4d-86d5-eb2109118cc9.png">

<img width="961" alt="スクリーンショット 2022-09-07 15 22 38" src="https://user-images.githubusercontent.com/86900758/188803734-e531a69f-c0dc-48ef-a1cb-23ab18ad0f21.png">

<img width="1408" alt="スクリーンショット 2022-09-07 17 58 08" src="https://user-images.githubusercontent.com/86900758/188836771-7b54a30a-c72a-4477-a48a-4109e1e8accd.png">


