### PR TITLE
#22 管理画面 Issue2 画面からイベント内容も登録出来るようにする

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -19,6 +19,7 @@ CREATE TABLE events (
   name VARCHAR(10) NOT NULL,
   start_at DATETIME,
   end_at DATETIME,
+  event_detail VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME
@@ -39,21 +40,21 @@ CREATE TABLE event_attendance (
 INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy");
 INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password=SHA("minn");
 
-INSERT INTO events SET name='縦モク', start_at='2022/09/10 21:00', end_at='2022/09/10 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='縦モク', start_at='2022/09/10 21:00', end_at='2022/09/10 23:00', event_detail='いっしょに学ぼう';
+INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00', event_detail='いっしょに開発しよう';
+INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00', event_detail='Mentorさんと学ぼう';
+INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00', event_detail='先輩に聞こう';
+INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00', event_detail='課題進めよう';
+INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00', event_detail='スーさんとお友達になろう';
+INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00', event_detail='先輩と仲良くなろう';
+INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00', event_detail='N予備見よう';
+INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00', event_detail='遅れちゃだめだよ';
+INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00', event_detail='質問用意してきてね';
+INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00', event_detail='課題をたくさんやろう';
+INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00', event_detail='毎週火曜日だよ';
+INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00', event_detail='釣り行く？笑';
+INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00', event_detail='優勝する！';
+INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00', event_detail='中華街行く？笑';
 
 INSERT INTO event_attendance SET event_id=1, user_id=1, status=1;
 INSERT INTO event_attendance SET event_id=1, user_id=2, status=1;

--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -5,23 +5,24 @@ require('../dbconnect.php');
 if(!empty($_POST['name'])) {
   try {
 
-    $stmt = $db->prepare('INSERT INTO events (name, start_at, end_at) VALUES (:name, :start_at, :end_at)');
+    $stmt = $db->prepare('INSERT INTO events (name, start_at, end_at, event_detail) VALUES (:name, :start_at, :end_at, :event_detail)');
   
     $name = $_POST['name'];
     $start_at = $_POST['start_at'];
     $end_at = $_POST['end_at'];
+    $event_detail = $_POST['event_detail'];
     
     $param = array(
       ':name' => $name,
       ':start_at' => $start_at,
       ':end_at' => $end_at,
+      ':event_detail' => $event_detail,
     );
   
     $stmt->execute($param);
   }catch (PDOException $e) {
     echo 'データベースにアクセスできません！'.$e->getMessage();
 }
-  
   } 
   
 ?>
@@ -64,6 +65,9 @@ if(!empty($_POST['name'])) {
     </div>
     <div>
       <p>終了時間<br><input type="datetime-local" name="end_at"></p>
+    </div>
+    <div>
+      <p>イベント内容<br><input type="text" name="event_detail"></p>
     </div>
     <div>
     <button type="submit" name="button">登録する</button>


### PR DESCRIPTION
## 関連イシュー
#22 管理画面 Issue2 画面からイベント内容も登録出来るようにする

## 検証したこと
- 管理画面からイベント名、開催日時、イベント内容を入力して、イベント登録できることを確認しました
- ユーザー画面の一覧に登録したイベントが追加されたことを確認しました

## 備考
管理者のみログインできるのは以下のPRで追加実装しています

## 関連プルリク
#39 #48 #54 

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="484" alt="スクリーンショット 2022-09-07 15 47 47" src="https://user-images.githubusercontent.com/86900758/188808862-b1f056f2-2a60-42a6-8328-7428ed5255bc.png">

<img width="1269" alt="スクリーンショット 2022-09-07 15 48 26" src="https://user-images.githubusercontent.com/86900758/188808893-77c2afa6-199a-4352-a0ea-629b86c6ac67.png">
<img width="1421" alt="スクリーンショット 2022-09-07 17 55 49" src="https://user-images.githubusercontent.com/86900758/188837028-ea2428bd-d577-4eaf-ac06-ceb8bd6eebfb.png">


