### PR TITLE
【追加・修正PR】DBに保存したハッシュ値と入力されたパスワードが一致しているかの確認に不備があったため修正

### DIFF
--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -34,7 +34,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
   //ユーザー情報があれば変数に格納
   if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     //パスワードがあっているか確認
-    if (sha1(($datas['password']) === $row['password'])) {
+    if (sha1($datas['password']) === $row['password']) {
 
       //セッション変数にログイン情報を格納
       $_SESSION["loggedin"] = true;

--- a/src/index.php
+++ b/src/index.php
@@ -2,11 +2,6 @@
 require('dbconnect.php');
 
 session_start();
-// セッション変数 $_SESSION["loggedin"]を確認。ログイン済だったらウェルカムページへリダイレクト
-if(!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true){
-    header("location: auth/login");
-    exit;
-}
 
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
 $events = $stmt->fetchAll();


### PR DESCRIPTION
## 関連イシュー
#8 ログイン機能 Issue2 パスワードを平文で保存せず、ハッシュ化する

## 関連PR
#29 （このPRでは #8 を行う際に、間違ったパスワードを入力してもログインできる状態にしてしまった）

## 検証したこと
- [x] DBに保存したハッシュ値と入力されたパスワードが一致していない時にログインを防ぐ

## エビデンス
![スクリーンショット (642)](https://user-images.githubusercontent.com/94539342/188900017-8d0afb91-5072-4c9e-a15d-88af450d3852.png)