### PR TITLE
#2 イベント一覧 Issue2 開催日が近いもの順にソート

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -41,9 +41,9 @@ INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA
 INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password=SHA("minn");
 
 INSERT INTO events SET name='縦モク', start_at='2022/09/10 21:00', end_at='2022/09/10 23:00', event_detail='いっしょに学ぼう';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00', event_detail='いっしょに開発しよう';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00', event_detail='Mentorさんと学ぼう';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00', event_detail='先輩に聞こう';
+INSERT INTO events SET name='横モク', start_at='2022/10/02 21:00', end_at='2022/10/02 23:00', event_detail='いっしょに開発しよう';
+INSERT INTO events SET name='スペモク', start_at='2022/11/03 20:00', end_at='2022/11/03 22:00', event_detail='Mentorさんと学ぼう';
+INSERT INTO events SET name='スペシャル縦モク', start_at='2022/09/18 21:00', end_at='2022/09/18 23:00', event_detail='先輩に聞こう';
 INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00', event_detail='課題進めよう';
 INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00', event_detail='スーさんとお友達になろう';
 INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00', event_detail='先輩と仲良くなろう';

--- a/src/index.php
+++ b/src/index.php
@@ -10,7 +10,7 @@ if(!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true){
 }
 
 
-$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id where end_at >= now()  GROUP BY events.id');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id where end_at >= now()  GROUP BY events.id ORDER BY events.start_at ASC');
 $events = $stmt->fetchAll();
 
 function get_day_of_week ($w) {


### PR DESCRIPTION
## 関連イシュー
#2 イベント一覧 Issue2 開催日が近いもの順にソート

## 検証したこと
開催日がが近い順＝日付が若い（近い）順＝昇順に上から掲載されていることを確認。

## エビデンス
![image](https://user-images.githubusercontent.com/86918664/188902935-022325fb-cc1f-46bc-8b4a-6a58fe9ce177.png)

