### PR TITLE
【追加・編集PR】 管理者画面に遷移する際にログイン状態状態を保持しているか確認

### DIFF
--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -1,6 +1,13 @@
 <?php
 session_start();
 require('../dbconnect.php');
+
+if (isset($_SESSION['start']) && (time() - $_SESSION['start'] > 10)) {
+  session_unset(); 
+  session_destroy(); 
+  header("location: ../auth/login");
+}
+
 // セッション変数 $_SESSION["loggedin"]を確認。ログイン済だったらウェルカムページへリダイレクト
 if(!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true){
     header("location: ../auth/login");

--- a/src/index.php
+++ b/src/index.php
@@ -3,6 +3,12 @@ require('dbconnect.php');
 
 
 session_start();
+if (isset($_SESSION['start']) && (time() - $_SESSION['start'] > 10)) {
+  session_unset(); 
+  session_destroy(); 
+  header("location: auth/login");
+}
+$_SESSION['start'] = time();
 // セッション変数 $_SESSION["loggedin"]を確認。ログイン済だったらウェルカムページへリダイレクト
 if(!isset($_SESSION["loggedin"]) || $_SESSION["loggedin"] !== true){
     header("location: auth/login");
@@ -36,11 +42,9 @@ function get_day_of_week ($w) {
       <div class="h-full">
         <img src="img/header-logo.png" alt="" class="h-full">
       </div>
-      <!-- 
       <div>
-        <a href="/auth/login" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">ログイン</a>
+        <a href="./admin/event_registration.php" class="text-white bg-blue-400 px-4 py-2 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-200">管理者画面</a>
       </div>
-      -->
     </div>
   </header>
 


### PR DESCRIPTION
## 関連イシュー
#21 管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空
#22 管理画面 Issue2 画面からイベント内容も登録出来るようにする
#23 管理画面 Issue3 画面からイベント情報を変更出来るようにする

## 関連PR
#33 #34 #47

## 検証したこと
- [x] ユーザー画面から管理者画面に遷移するときにログイン情報を保持していたらそのまま管理者画面に移動
- [x] 保持していなかったらログイン画面に戻る
※今回はログイン情報の保持をログイン後10秒で破棄している

## エビデンス
ログイン関連のため当日のプレゼンで説明