### PR TITLE
#9 ログイン機能 Issue3 管理者が対応しなくてもパスワード再設定が出来るようにする

### DIFF
--- a/src/auth/login/forget_password.php
+++ b/src/auth/login/forget_password.php
@@ -1,0 +1,62 @@
+<?php
+require('../../dbconnect.php');
+
+$inputted_email = $_POST['inputted_email'];
+
+$stmt = $db->prepare('SELECT name, email FROM users WHERE email = :inputted_email');
+$stmt->bindValue(':inputted_email', $inputted_email);
+$stmt->execute();
+$address = $stmt->fetch(pdo::FETCH_ASSOC);
+
+if(isset($_POST['inputted_email'])) {
+  if (!empty($address)) {
+    // 【メール送信】
+    mb_language('ja');
+    mb_internal_encoding('UTF-8');
+ 
+    $to = $address['email'];
+    $subject = "パスワードリセット";
+    $body = "本文";
+    $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+ 
+    $name = $address['name'];
+    $body = <<<EOT
+    {$name}さん
+    以下のリンクからパスワードリセットを行ってください。
+    http://localhost/auth/login/update_password.php
+  EOT;
+ 
+    mb_send_mail($to, $subject, $body, $headers);
+   echo 'そのアドレス宛にメールを送信しました';
+ 
+ } else {
+   echo 'そのアドレスは未登録です';
+ } 
+
+}
+
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワードリセット手続き</title>
+</head>
+
+<body>
+
+  <h1>パスワードの再設定</h1>
+  <form action="./forget_password.php" method="post">
+    <p>登録しているメールアドレスを入力してください</p>
+    <input name="inputted_email" type="text">
+    <button type="submit">送信</button>
+  </form>
+
+</body>
+
+</html>

--- a/src/auth/login/forget_password.php
+++ b/src/auth/login/forget_password.php
@@ -3,7 +3,7 @@ require('../../dbconnect.php');
 
 $inputted_email = $_POST['inputted_email'];
 
-$stmt = $db->prepare('SELECT name, email FROM users WHERE email = :inputted_email');
+$stmt = $db->prepare('SELECT id, name, email FROM users WHERE email = :inputted_email');
 $stmt->bindValue(':inputted_email', $inputted_email);
 $stmt->execute();
 $address = $stmt->fetch(pdo::FETCH_ASSOC);
@@ -15,6 +15,7 @@ if(isset($_POST['inputted_email'])) {
     mb_internal_encoding('UTF-8');
  
     $to = $address['email'];
+    $id = $address['id'];
     $subject = "パスワードリセット";
     $body = "本文";
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
@@ -23,7 +24,7 @@ if(isset($_POST['inputted_email'])) {
     $body = <<<EOT
     {$name}さん
     以下のリンクからパスワードリセットを行ってください。
-    http://localhost/auth/login/update_password.php
+    http://localhost/auth/login/update_password.php?id={$id}
   EOT;
  
     mb_send_mail($to, $subject, $body, $headers);

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -94,7 +94,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         <input type="submit" value="ログイン" class="cursor-pointer w-full p-3 text-md text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300">
       </form>
       <div class="text-center text-xs text-gray-400 mt-6">
-        <a href="/">パスワードを忘れた方はこちら</a>
+        <a href="./forget_password.php">パスワードを忘れた方はこちら</a>
       </div>
     </div>
   </main>

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -3,11 +3,12 @@ require ("../../dbconnect.php");
 
 session_start();
 
+
 // セッション変数 $_SESSION["loggedin"]を確認。ログイン済だったらウェルカムページへリダイレクト
-if (isset($_SESSION["loggedin"]) && $_SESSION["loggedin"] === true) {
-  header("location: ../../index.php");
-  exit;
-}
+// if (isset($_SESSION["loggedin"]) && $_SESSION["loggedin"] === true) {
+//   header("location: ../../index.php");
+//   exit;
+// }
 
 //POSTされてきたデータを格納する変数の定義と初期化
 $datas = [

--- a/src/auth/login/update_password.php
+++ b/src/auth/login/update_password.php
@@ -1,0 +1,2 @@
+<?php
+echo 'yoooooooo';

--- a/src/auth/login/update_password.php
+++ b/src/auth/login/update_password.php
@@ -1,2 +1,56 @@
 <?php
-echo 'yoooooooo';
+require('../../dbconnect.php');
+
+if (isset($_GET['id'])) {
+  $id = htmlspecialchars($_GET['id']);
+
+  $stmt = $db->prepare('SELECT * FROM users WHERE id = ?');
+  $stmt->execute(array($id));
+  $applicant = $stmt->fetch(pdo::FETCH_ASSOC);
+}
+
+if(isset($_POST['new_password'])) {
+
+  try {
+      // 送信された値を取得
+      $new_password = sha1($_POST['new_password']);
+      $sql = 'UPDATE users SET
+      password = :new_password WHERE id = :id';
+      $stmt = $db->prepare($sql);
+      $stmt->bindParam(":id", $id, PDO::PARAM_INT);
+      $stmt->bindValue(":new_password",  $new_password, PDO::PARAM_STR);
+      $stmt->execute();
+      echo '登録されたので再度ログイの願いします' . 'http://localhost/auth/login/';
+      exit();
+  } catch (PDOException $e) {
+      exit('データベースに接続できませんでした。' . $e->getMessage());
+  }
+}
+
+
+
+
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>新規パスワード入力</title>
+</head>
+
+<body>
+  <h1>新規パスワード登録</h1>
+  <form action="./update_password.php?id=1" method="post">
+    <p><?php echo $applicant['name'];?>さんが登録したいパスワードを以下に入力してください</p>
+    <input name="new_password" type="text">
+    <button type="submit">送信</button>
+  </form>
+
+</body>
+
+</html>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#9 ログイン機能 Issue3 管理者が対応しなくてもパスワード再設定が出来るようにする
## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- パスワードを忘れた方はこちらを押すと再発行のページに遷移する
- データベースに登録されているメールアドレスを入力した場合のみメールが届く
- メールにある再設定リンクで、GETメソッドでユーザー情報を取得している
- 登録されたパスワードがハッシュ化された状態で上書きされる
- 新しいパスワードでログインできる

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
<img width="378" alt="スクリーンショット 2022-09-08 7 49 01" src="https://user-images.githubusercontent.com/86900758/188996802-91192b67-4a98-4e7e-ba0e-a50c01febf2c.png">

<img width="410" alt="スクリーンショット 2022-09-08 7 49 22" src="https://user-images.githubusercontent.com/86900758/188996838-dbe59ba3-754a-4c05-8857-33b1ecebf5bb.png">
<img width="1156" alt="スクリーンショット 2022-09-08 7 49 38" src="https://user-images.githubusercontent.com/86900758/188996865-612a06c8-cf39-412f-a420-698228d41b9f.png">

<img width="664" alt="スクリーンショット 2022-09-08 7 49 56" src="https://user-images.githubusercontent.com/86900758/188996892-aa7cc78e-196b-4ea7-a30b-73d80607345a.png">
<img width="525" alt="スクリーンショット 2022-09-08 7 50 09" src="https://user-images.githubusercontent.com/86900758/188996920-5f8f08ac-2c35-461b-be2d-b16d259a3066.png">
<img width="1047" alt="スクリーンショット 2022-09-08 7 50 41" src="https://user-images.githubusercontent.com/86900758/188996962-34d27f2d-d5ba-47b5-bb5e-f25dd4c5bb75.png">

