### PR TITLE
#23 管理画面 Issue3 画面からイベント情報を変更出来るようにする

### DIFF
--- a/src/admin/event_edit.php
+++ b/src/admin/event_edit.php
@@ -1,0 +1,63 @@
+<?php
+require('../dbconnect.php');
+
+if (isset($_GET['id'])) {
+  $id = htmlspecialchars($_GET['id']);
+
+  $stmt = $db->prepare('SELECT * FROM events WHERE id = ?');
+  $stmt->execute(array($id));
+  $event = $stmt->fetchAll(pdo::FETCH_ASSOC);
+}
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/css/admin.css">
+  <title>イベント登録</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <p><a href="./event_registration.php">イベント登録</a></p>
+    </div>
+    <div class="header_title">
+      <p><a href="./event_list.php">イベント一覧</a></p>
+    </div>
+  </header>
+  <main>
+    <div>
+      <h1>イベント変更</h1>
+    </div>
+    <form action="./event_edit.php" method="post" class="registration_form">
+      <div>
+        <p>イベント名<br><input type="text" value="<?php echo $event[0]['name'] ?>"></p>
+      </div>
+      <div>
+        <p>開始時間<br><input type="datetime-local" value="<?php echo $event[0]['start_at'] ?>"></p>
+      </div>
+      <div>
+        <p>終了時間<br><input type="datetime-local" value="<?php echo $event[0]['end_at'] ?>"></p>
+      </div>
+      <div>
+        <p>イベント内容<br><input type="text" value="<?php echo $event[0]['event_detail'] ?>"></p>
+      </div>
+      <div>
+        <input type="submit" value="変更">
+      </div>
+      </form>
+
+
+</main>
+</body>
+
+</html>

--- a/src/admin/event_edit.php
+++ b/src/admin/event_edit.php
@@ -3,11 +3,68 @@ require('../dbconnect.php');
 
 if (isset($_GET['id'])) {
   $id = htmlspecialchars($_GET['id']);
-
   $stmt = $db->prepare('SELECT * FROM events WHERE id = ?');
   $stmt->execute(array($id));
   $event = $stmt->fetchAll(pdo::FETCH_ASSOC);
 }
+
+if (isset($_POST['name'])) {
+  $id = $event[0]['id'];
+
+  try {
+      // 送信された値を取得
+      $name = $_POST['name'];
+      $start_at = $_POST['start_at'];
+      $end_at = $_POST['end_at'];
+      $event_detail = $_POST['event_detail'];
+
+      echo $event_detail;
+
+      $sql = 'UPDATE events SET
+      name = :name, start_at = :start_at, end_at = :end_at, event_detail = :event_detail WHERE id = :id';
+      $stmt = $db->prepare($sql);
+      $stmt->bindParam(":id", $id, PDO::PARAM_INT);
+
+      $stmt->bindValue(":name",  $name, PDO::PARAM_STR);
+      // 
+      $stmt->bindValue(":start_at",  $start_at);
+      // 
+      $stmt->bindValue(":end_at",  $end_at);
+      // 
+      $stmt->bindValue(":event_detail",  $event_detail);
+      $stmt->execute();
+
+      echo '更新しました';
+      exit();
+  } catch (PDOException $e) {
+      exit('データベースに接続できませんでした。' . $e->getMessage());
+  }
+}
+
+// if (isset($_POST['name'])) {
+//   $db->beginTransaction();
+//   $name = $_POST['name'];
+//     try {
+//       $stmt = $db->prepare('UPDATE events SET name = :name, start_at = :start_at, end_at = :end_at, event_detail = :event_detail WHERE id = :id');
+      
+//       $id = $event[0]['id'];
+//       $name = $_POST['name'];
+//       $start_at = $_POST['start_at'];
+//       $end_at = $_POST['end_at'];
+//       $event_detail = $_POST['event_detail'];
+
+//       $stmt->bindParam(':id', $id, PDO::PARAM_INT);
+//       $stmt->bindParam(':name', $name, PDO::PARAM_STR);
+//       $stmt->bindParam(':start_at', $start_at);
+//       $stmt->bindParam(':end_at', $end_at);
+//       $stmt->bindParam(':event_detail', $event_detail, PDO::PARAM_STR);
+
+//       $db->commit();
+//       echo '更新しました';
+//     } catch (PDOException $e) {
+//       echo 'データベースにアクセスできません！'.$e->getMessage();
+//     }
+//   }
 
 ?>
 
@@ -38,26 +95,23 @@ if (isset($_GET['id'])) {
     <div>
       <h1>イベント変更</h1>
     </div>
-    <form action="./event_edit.php" method="post" class="registration_form">
+    <form action="./event_edit.php" method="POST" class="registration_form">
       <div>
-        <p>イベント名<br><input type="text" value="<?php echo $event[0]['name'] ?>"></p>
+        <p>イベント名<br><input name="name" type="text" value="<?php echo $event[0]['name'] ?>"></p>
       </div>
       <div>
-        <p>開始時間<br><input type="datetime-local" value="<?php echo $event[0]['start_at'] ?>"></p>
+        <p>開始時間<br><input name="start_at" type="datetime-local" value="<?php echo $event[0]['start_at'] ?>"></p>
       </div>
       <div>
-        <p>終了時間<br><input type="datetime-local" value="<?php echo $event[0]['end_at'] ?>"></p>
+        <p>終了時間<br><input name="end_at" type="datetime-local" value="<?php echo $event[0]['end_at'] ?>"></p>
       </div>
       <div>
-        <p>イベント内容<br><input type="text" value="<?php echo $event[0]['event_detail'] ?>"></p>
+        <p>イベント内容<br><input name="event_detail" type="text" value="<?php echo $event[0]['event_detail'] ?>"></p>
       </div>
       <div>
-        <input type="submit" value="変更">
+        <button name="update" type="submit">変更</button>
       </div>
       </form>
-
-
 </main>
 </body>
-
 </html>

--- a/src/admin/event_edit.php
+++ b/src/admin/event_edit.php
@@ -9,23 +9,21 @@ if (isset($_GET['id'])) {
 }
 
 if (isset($_POST['name'])) {
-  $id = $event[0]['id'];
-
   try {
+      $id = $_POST['id'];
       // 送信された値を取得
       $name = $_POST['name'];
-      $start_at = $_POST['start_at'];
-      $end_at = $_POST['end_at'];
+      $start_at = str_replace("T", " ", $_POST['start_at']) .":00";
+      $end_at = str_replace("T", " ", $_POST['end_at']) .":00";
       $event_detail = $_POST['event_detail'];
 
       echo $event_detail;
 
-      $sql = 'UPDATE events SET
-      name = :name, start_at = :start_at, end_at = :end_at, event_detail = :event_detail WHERE id = :id';
+      $sql = 'UPDATE events SET name = :name, start_at = :start_at, end_at = :end_at, event_detail = :event_detail WHERE id = :id';
       $stmt = $db->prepare($sql);
-      $stmt->bindParam(":id", $id, PDO::PARAM_INT);
+      $stmt->bindValue(":id", $id);
 
-      $stmt->bindValue(":name",  $name, PDO::PARAM_STR);
+      $stmt->bindValue(":name", $name);
       // 
       $stmt->bindValue(":start_at",  $start_at);
       // 
@@ -111,6 +109,7 @@ if (isset($_POST['name'])) {
       <div>
         <button name="update" type="submit">変更</button>
       </div>
+      <input name="id" type="hidden" value="<?php echo $event[0]['id'] ?>">
       </form>
 </main>
 </body>

--- a/src/admin/event_list.php
+++ b/src/admin/event_list.php
@@ -1,0 +1,63 @@
+<?php
+
+require('../dbconnect.php');
+$stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
+$events = $stmt->fetchAll();
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../admin/css/admin.css">
+  <title>イベント一覧</title>
+</head>
+
+<body>
+  <header>
+    <div class="header_logo">
+      <img src="../img/header-logo.png" alt="posseロゴ">
+    </div>
+    <div class="header_title">
+      <p><a href="./event_registration.php">イベント登録</a></p>
+    </div>
+    <div class="header_title">
+      <p><a href="./event_list.php">イベント一覧</a></p>
+    </div>
+  </header>
+  <main>
+    <div>
+      <h1>イベント一覧</h1>
+    </div>
+
+    <?php foreach ($events as $event) : ?>
+      <?php
+      $start_date = strtotime($event['start_at']);
+      $end_date = strtotime($event['end_at']);
+      ?>
+      <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
+        <div>
+          <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
+          <p><?php echo date("Y年m月d日", $start_date); ?></p>
+          <p class="text-xs text-gray-600">
+            <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
+          </p>
+        </div>
+        <div class="flex flex-col justify-between text-right">
+        </div>
+      </div>
+      <form action="./event_edit.php" method="POST" class="each_event_edit">
+        <p><a href="./event_edit.php?id=<?php echo $event['id']; ?>">編集</a></p>
+      </form>
+    <?php endforeach; ?>
+    <div class="each_event">
+      
+    </div>
+
+  </main>
+</body>
+
+</html>

--- a/src/admin/event_registration.php
+++ b/src/admin/event_registration.php
@@ -45,12 +45,12 @@ if(!empty($_POST['name'])) {
     </div>
     <div class="header_title">
       <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
-      <p><a href="event_registration.html">イベント登録</a></p>
+      <p><a href="./event_registration.php">イベント登録</a></p>
     </div>
-    <!-- <div class="header_title"> -->
+    <div class="header_title">
     <!-- 後に変更！！！！！！！！！！！！！！！！！！ -->
-    <!-- <p><a href="event_registration.html">イベント一覧</a></p>
-    </div> -->
+    <p><a href="./event_list.php">イベント一覧</a></p>
+    </div>
   </header>
   <main>
   <div>


### PR DESCRIPTION
## 関連イシュー
#23 管理画面 Issue3 画面からイベント情報を変更出来るようにする

## 関連プルリク
#39 #48 #54 #57 

## 検証したこと
- 管理画面から登録済みのイベント一覧が確認できること、
- イベントを選択してイベント名、開催日時、イベント内容を変更できること
- 管理画面には管理者のみログイン出来る

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->

### イベント一覧
<img width="652" alt="スクリーンショット 2022-09-08 21 12 52" src="https://user-images.githubusercontent.com/86900758/189118885-9c8b2dc8-1d56-4922-9394-c063a76b5937.png">

### 編集画面
<img width="589" alt="スクリーンショット 2022-09-08 21 13 59" src="https://user-images.githubusercontent.com/86900758/189119072-d98d257e-05bf-4521-a9c4-efd6629eea8d.png">

### 変更後（1番上のたてもく）
<img width="565" alt="スクリーンショット 2022-09-08 21 14 29" src="https://user-images.githubusercontent.com/86900758/189119155-624d0a73-d4d0-46f1-b3d9-828d1a105fb2.png">

### 管理者じゃない人がアクセス
<img width="609" alt="スクリーンショット 2022-09-08 21 14 57" src="https://user-images.githubusercontent.com/86900758/189119227-6f0dd7e8-b3fe-4d98-97e2-c32dd0494ab9.png">
