### PR TITLE
#15 トップページに自身の回答状況を表示する

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -3,7 +3,7 @@ require('dbconnect.php');
 
 
 session_start();
-if (isset($_SESSION['start']) && (time() - $_SESSION['start'] > 100000)) {
+if (isset($_SESSION['start']) && (time() - $_SESSION['start'] > 10)) {
   session_unset();
   session_destroy();
   header("location: auth/login");


### PR DESCRIPTION
## 関連イシュー
#15 トップページに自身の回答状況を表示する

## 検証したこと
・全て、参加、不参加、未回答のいずれにおいても該当するイベントの参加回答状況が表示される
・未回答の場合は、開催日の３日前が期限として表示される

## エビデンス
![image](https://user-images.githubusercontent.com/86918664/189033669-d2860a70-7473-4c20-a742-3f332cacb6c6.png)
![image](https://user-images.githubusercontent.com/86918664/189033840-6b167bb6-92bb-488e-b427-ceab836a97a9.png)
![image](https://user-images.githubusercontent.com/86918664/189033780-bd770447-0c09-49c9-a61b-c1810ff45ce3.png)
![image](https://user-images.githubusercontent.com/86918664/189033872-94a043f8-931f-431c-b15e-fe1586af24f3.png)