### PR TITLE
#27 未回答管理 Issue4 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ slack通知

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -9,6 +9,7 @@ CREATE TABLE users (
   email  VARCHAR(255) COLLATE utf8_bin,
   password VARCHAR(255) NOT NULL,
   status TINYINT(1) NOT NULL DEFAULT '0',
+  slack_id VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME
@@ -37,9 +38,9 @@ CREATE TABLE event_attendance (
   deleted_at DATETIME
 );
 
-INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy");
-INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password=SHA("minn");
-INSERT INTO users SET name='ゆやまともはる', email='tomo@posse.com', password=SHA("umeru"), status=1;
+INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy"), slack_id='U041JKK755Y';
+INSERT INTO users SET name='遠藤愛期', email='manaki@posse.com', password=SHA("manaki"), slack_id='U041XECTJQH';
+INSERT INTO users SET name='平野隆二', email='tomo@posse.com', password=SHA("umeru"), status=1;
 
 INSERT INTO events SET name='縦モク', start_at='2022/09/12 21:00', end_at='2022/09/10 23:00', event_detail='いっしょに学ぼう';
 INSERT INTO events SET name='横モク', start_at='2022/09/09 21:00', end_at='2022/09/09 21:00', event_detail='いっしょに開発しよう';
@@ -121,13 +122,13 @@ INSERT INTO event_attendance SET event_id=15, user_id=2, status=1;
 INSERT INTO event_attendance SET event_id=15, user_id=3, status=0;
 INSERT INTO event_attendance SET event_id=16, user_id=1, status=0;
 INSERT INTO event_attendance SET event_id=16, user_id=2, status=0;
-INSERT INTO event_attendance SET event_id=16, user_id=3, status=0;
+INSERT INTO event_attendance SET event_id=16, user_id=3, status=1;
 INSERT INTO event_attendance SET event_id=17, user_id=1, status=0;
 INSERT INTO event_attendance SET event_id=17, user_id=2, status=0;
 INSERT INTO event_attendance SET event_id=17, user_id=3, status=0;
 INSERT INTO event_attendance SET event_id=18, user_id=1, status=0;
 INSERT INTO event_attendance SET event_id=18, user_id=2, status=0;
-INSERT INTO event_attendance SET event_id=18, user_id=3, status=0;
+INSERT INTO event_attendance SET event_id=18, user_id=3, status=1;
 INSERT INTO event_attendance SET event_id=19, user_id=1, status=0;
 INSERT INTO event_attendance SET event_id=19, user_id=2, status=0;
 INSERT INTO event_attendance SET event_id=19, user_id=3, status=0;

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -9,6 +9,7 @@ CREATE TABLE users (
   email  VARCHAR(255) COLLATE utf8_bin,
   password VARCHAR(255) NOT NULL,
   status TINYINT(1) NOT NULL DEFAULT '0',
+  slack_id VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   deleted_at DATETIME
@@ -37,8 +38,8 @@ CREATE TABLE event_attendance (
   deleted_at DATETIME
 );
 
-INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy");
-INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password=SHA("minn");
+INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy"), slack_id='U041JKK755Y';
+INSERT INTO users SET name='尾関なな海', email='nanami@posse.com', password=SHA("minn"), slack_id='U041XECTJQH';
 INSERT INTO users SET name='ゆやまともはる', email='tomo@posse.com', password=SHA("umeru"), status=1;
 
 INSERT INTO events SET name='縦モク', start_at='2022/09/12 21:00', end_at='2022/09/10 23:00', event_detail='いっしょに学ぼう';

--- a/src/admin/user_registration.php
+++ b/src/admin/user_registration.php
@@ -15,10 +15,11 @@ if (isset($_SESSION['user_id']) && $_SESSION['time'] + 60 * 60 * 24 > time()) {
 
 if (!empty($_POST['name'])) {
   try {
-    $stmt = $db->prepare('INSERT INTO users (name, email, password, status) VALUES (:name, :email, :password, :status)');
+    $stmt = $db->prepare('INSERT INTO users (name, email, password, slack_id, status) VALUES (:name, :email, :password, :slack_id, :status)');
     $name = $_POST['name'];
     $email = $_POST['email'];
     $password = sha1($_POST['password']);
+    $slack_id = $_POST['slack_id'];
     $radio = $_POST['status'];
     if (isset($radio)) {
       $status = 1;
@@ -29,6 +30,7 @@ if (!empty($_POST['name'])) {
       ':name' => $name,
       ':email' => $email,
       ':password' => $password,
+      ':slack_id' => $slack_id,
       ':status' => $status,
     );
     $stmt->execute($param);
@@ -88,6 +90,9 @@ if (!empty($_POST['name'])) {
       </div>
       <div>
         <p>パスワード<br><input type="text" name="password"></p>
+      </div>
+      <div>
+        <p>SlackのユーザーID<br><input type="text" name="slack_id"></p>
       </div>
       <div>
         <p>管理者はチェックを入れてください<br><input type="radio" name="status"></p>

--- a/src/api/one_day_before_slack.php
+++ b/src/api/one_day_before_slack.php
@@ -1,0 +1,26 @@
+<?php
+$url = "https://hooks.slack.com/services/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";
+$message = [
+  "channel" => "はっかそんだあ",
+  "text" => "イ"
+];
+
+$ch = curl_init();
+
+$options = [
+  CURLOPT_URL => $url,
+  // 返り値を文字列で返す
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_SSL_VERIFYPEER => false,
+  // POST
+  CURLOPT_POST => true,
+  CURLOPT_POSTFIELDS => http_build_query([
+    'payload' => json_encode($message)
+  ])
+];
+
+curl_setopt_array($ch, $options);
+curl_exec($ch);
+
+// echo $ch;
+curl_close($ch);

--- a/src/api/one_day_before_slack.php
+++ b/src/api/one_day_before_slack.php
@@ -1,5 +1,5 @@
 <?php
-$url = "https://hooks.slack.com/services/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";
+$url = "https://hooks.slack.com/services/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";
 $message = [
   "channel" => "はっかそんだあ",
   "text" => "イ"

--- a/src/api/three_days_before_slack.php
+++ b/src/api/three_days_before_slack.php
@@ -19,7 +19,7 @@ try {
 
     $three_days_after = date("Y-m-d", strtotime("+3 day"));
     if ($event_date == $three_days_after) {
-      $stmt = $db->prepare('SELECT users.name, users.email, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 0 AND events.id = :event_id');
+      $stmt = $db->prepare('SELECT users.name, users.email, users.slack_id, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 0 AND events.id = :event_id');
       $stmt->bindValue(':event_id', $array['id']);
       $stmt->execute();
       $participants = $stmt->fetchAll(pdo::FETCH_ASSOC); 
@@ -34,12 +34,12 @@ try {
         $date = $event_date;
         $event = $array['name'];
         $event_detail = $array['event_detail'];
-        $slack_id = 'U041JKK755Y';
+        $slack_id = $participant['slack_id'];
 
         $url = "https://hooks.slack.com/services/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";
         $message = [
           "channel" => "はっかそんだあ",
-          "text" => "<@${slack_id}>さん
+          "text" => "<@${slack_id}>${name}さん
           ${date}に${event}を開催します。
           説明：${event_detail}
           参加／不参加の回答をお願いします。

--- a/src/api/three_days_before_slack.php
+++ b/src/api/three_days_before_slack.php
@@ -19,7 +19,7 @@ try {
 
     $three_days_after = date("Y-m-d", strtotime("+3 day"));
     if ($event_date == $three_days_after) {
-      $stmt = $db->prepare('SELECT users.name, users.email, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 0 AND events.id = :event_id');
+      $stmt = $db->prepare('SELECT users.name, users.email, users.slack_id, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 0 AND events.id = :event_id');
       $stmt->bindValue(':event_id', $array['id']);
       $stmt->execute();
       $participants = $stmt->fetchAll(pdo::FETCH_ASSOC); 
@@ -34,9 +34,9 @@ try {
         $date = $event_date;
         $event = $array['name'];
         $event_detail = $array['event_detail'];
-        $slack_id = 'U041JKK755Y';
+        $slack_id = $participant['slack_id'];
 
-        $url = "https://hooks.slack.com/services/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";
+        $url = "https://hooks.slack.com/services/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";
         $message = [
           "channel" => "はっかそんだあ",
           "text" => "<@${slack_id}>さん

--- a/src/api/three_days_before_slack.php
+++ b/src/api/three_days_before_slack.php
@@ -1,0 +1,74 @@
+<?php
+require('../dbconnect.php');
+try {
+  $stmt = $db->prepare('SELECT id, name, start_at, end_at, event_detail from events');
+  $stmt->execute();
+  $events = $stmt->fetchAll(pdo::FETCH_ASSOC);
+
+  foreach ($events as $index => $event) {
+    $array = [
+      'id' => $event['id'],
+      'name' => $event['name'],
+      'date' => date("Y年m月d日", $start_date),
+      'start_at' => date("H:i", $start_date),
+      'end_at' => date("H:i", $end_date),
+      'event_detail' => $event['event_detail'],
+    ];
+
+    $event_date = substr($event['start_at'], 0, 10);
+
+    $three_days_after = date("Y-m-d", strtotime("+3 day"));
+    if ($event_date == $three_days_after) {
+      $stmt = $db->prepare('SELECT users.name, users.email, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 0 AND events.id = :event_id');
+      $stmt->bindValue(':event_id', $array['id']);
+      $stmt->execute();
+      $participants = $stmt->fetchAll(pdo::FETCH_ASSOC); 
+
+      foreach ($participants as $index => $participant) {
+        $to = $participant['email'];
+        $subject = "イベントリマインド";
+        $body = "本文";
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+        $name = $participant['name'];
+        $date = $event_date;
+        $event = $array['name'];
+        $event_detail = $array['event_detail'];
+        $slack_id = 'U041JKK755Y';
+
+        $url = "https://hooks.slack.com/services/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";
+        $message = [
+          "channel" => "はっかそんだあ",
+          "text" => "<@${slack_id}>さん
+          ${date}に${event}を開催します。
+          説明：${event_detail}
+          参加／不参加の回答をお願いします。
+          http://localhost/"
+        ];
+
+        $ch = curl_init();
+
+        $options = [
+          CURLOPT_URL => $url,
+          // 返り値を文字列で返す
+          CURLOPT_RETURNTRANSFER => true,
+          CURLOPT_SSL_VERIFYPEER => false,
+          // POST
+          CURLOPT_POST => true,
+          CURLOPT_POSTFIELDS => http_build_query([
+            'payload' => json_encode($message)
+          ])
+        ];
+
+        curl_setopt_array($ch, $options);
+        curl_exec($ch);
+
+        // echo $ch;
+        curl_close($ch);
+      }
+    }
+  }
+} catch (PDOException $e) {
+  echo $e->getMessage();
+  exit();
+}


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
#27 未回答管理 Issue4 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ slack通知

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
- 送られるのは3日前のイベントのみ
- 未回答にのみメンションされる
- メッセージにはイベント名、内容、開催日時、回答を促す内容が記載されている

## エビデンス
###  備考
- 実行日は9/8でした

### イベント日時
<img width="1142" alt="スクリーンショット 2022-09-08 17 33 32" src="https://user-images.githubusercontent.com/86900758/189078489-4b163f7b-30e0-414e-9a64-bc954c0419db.png">

### 登録情報（status = 0が未回答）
<img width="839" alt="スクリーンショット 2022-09-08 17 51 09" src="https://user-images.githubusercontent.com/86900758/189079134-260a805a-287e-4a4d-bc80-194be58003dc.png">

### Slack画面
<img width="679" alt="スクリーンショット 2022-09-08 19 18 51" src="https://user-images.githubusercontent.com/86900758/189098000-12da27e3-3317-45af-b15c-a87b6cbc24b7.png">

