### PR TITLE
#20 通知機能 Issue4 イベントの前日にメールで通知する 通知する先は参加としている人のみ slack通知

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -40,7 +40,7 @@ CREATE TABLE event_attendance (
 
 INSERT INTO users SET name='石川朝香', email='asaka@posse.com', password=SHA("eddy"), slack_id='U041JKK755Y';
 INSERT INTO users SET name='遠藤愛期', email='manaki@posse.com', password=SHA("manaki"), slack_id='U041XECTJQH';
-INSERT INTO users SET name='平野隆二', email='tomo@posse.com', password=SHA("umeru"), status=1;
+INSERT INTO users SET name='平野隆二', email='tomo@posse.com', password=SHA("umeru"), status=1, slack_id='U041K71LBQT';
 
 INSERT INTO events SET name='縦モク', start_at='2022/09/12 21:00', end_at='2022/09/10 23:00', event_detail='いっしょに学ぼう';
 INSERT INTO events SET name='横モク', start_at='2022/09/09 21:00', end_at='2022/09/09 21:00', event_detail='いっしょに開発しよう';

--- a/src/api/one_day_before_slack.php
+++ b/src/api/one_day_before_slack.php
@@ -1,26 +1,74 @@
 <?php
-$url = "https://hooks.slack.com/services/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";
-$message = [
-  "channel" => "はっかそんだあ",
-  "text" => "イ"
-];
+require('../dbconnect.php');
+try {
+  $stmt = $db->prepare('SELECT id, name, start_at, end_at, event_detail from events');
+  $stmt->execute();
+  $events = $stmt->fetchAll(pdo::FETCH_ASSOC);
 
-$ch = curl_init();
+  foreach ($events as $index => $event) {
+    $array = [
+      'id' => $event['id'],
+      'name' => $event['name'],
+      'date' => date("Y年m月d日", $start_date),
+      'start_at' => date("H:i", $start_date),
+      'end_at' => date("H:i", $end_date),
+      'event_detail' => $event['event_detail'],
+    ];
 
-$options = [
-  CURLOPT_URL => $url,
-  // 返り値を文字列で返す
-  CURLOPT_RETURNTRANSFER => true,
-  CURLOPT_SSL_VERIFYPEER => false,
-  // POST
-  CURLOPT_POST => true,
-  CURLOPT_POSTFIELDS => http_build_query([
-    'payload' => json_encode($message)
-  ])
-];
+    $event_date = substr($event['start_at'], 0, 10);
 
-curl_setopt_array($ch, $options);
-curl_exec($ch);
+    $one_day_after = date("Y-m-d", strtotime("+1 day"));
+    if ($event_date == $one_day_after) {
+      $stmt = $db->prepare('SELECT users.name, users.email, users.slack_id, event_attendance.status FROM event_attendance left join users on event_attendance.user_id = users.id right join events on event_attendance.event_id = events.id where event_attendance.status = 1 AND events.id = :event_id');
+      $stmt->bindValue(':event_id', $array['id']);
+      $stmt->execute();
+      $participants = $stmt->fetchAll(pdo::FETCH_ASSOC); 
 
-// echo $ch;
-curl_close($ch);
+      foreach ($participants as $index => $participant) {
+        $to = $participant['email'];
+        $subject = "イベントリマインド";
+        $body = "本文";
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+        $name = $participant['name'];
+        $date = $event_date;
+        $event = $array['name'];
+        $event_detail = $array['event_detail'];
+        $slack_id = $participant['slack_id'];
+
+        $url = "https://hooks.slack.com/services/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";
+        $message = [
+          "channel" => "はっかそんだあ",
+          "text" => "<@${slack_id}>${name}さん
+          ${date}に${event}を開催します。
+          説明：${event_detail}
+          参加／不参加の回答をお願いします。
+          http://localhost/"
+        ];
+
+        $ch = curl_init();
+
+        $options = [
+          CURLOPT_URL => $url,
+          // 返り値を文字列で返す
+          CURLOPT_RETURNTRANSFER => true,
+          CURLOPT_SSL_VERIFYPEER => false,
+          // POST
+          CURLOPT_POST => true,
+          CURLOPT_POSTFIELDS => http_build_query([
+            'payload' => json_encode($message)
+          ])
+        ];
+
+        curl_setopt_array($ch, $options);
+        curl_exec($ch);
+
+        // echo $ch;
+        curl_close($ch);
+      }
+    }
+  }
+} catch (PDOException $e) {
+  echo $e->getMessage();
+  exit();
+}

--- a/src/api/three_days_before_slack.php
+++ b/src/api/three_days_before_slack.php
@@ -36,7 +36,7 @@ try {
         $event_detail = $array['event_detail'];
         $slack_id = $participant['slack_id'];
 
-        $url = "https://hooks.slack.com/services/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";
+        $url = "https://hooks.slack.com/services/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";
         $message = [
           "channel" => "はっかそんだあ",
           "text" => "<@${slack_id}>${name}さん


### PR DESCRIPTION
## 関連イシュー
#20 通知機能 Issue4 イベントの前日にメールで通知する 通知する先は参加としている人のみ slack通知

## 検証したこと
バッチを実行すると処理日がイベントの前日の場合Slackで通知する
メッセージの宛先は参加としている人のみ、チャンネルはチームごとに用意するチャンネル
メッセージにはイベント名、内容、開催日時を記載する

## エビデンス
### イベント日時
<img width="1131" alt="スクリーンショット 2022-09-08 17 33 19" src="https://user-images.githubusercontent.com/86900758/189076973-d7a8bd58-c70e-47b5-9bf4-0d3064776f50.png">

### 登録情報（status = 1が参加）
<img width="836" alt="スクリーンショット 2022-09-08 17 34 57" src="https://user-images.githubusercontent.com/86900758/189077229-04cd473c-f63b-4496-8cf3-d9f97888de27.png">
<img width="674" alt="スクリーンショット 2022-09-08 21 03 50" src="https://user-images.githubusercontent.com/86900758/189117273-43b024e3-8c90-48e3-9edf-4ade6df0dc5f.png">

